### PR TITLE
Update 'deprecated' helm charts stable repository

### DIFF
--- a/docs/collections/Build your very own self-hosting platform with Raspberry Pi and Kubernetes/(38)-install-and-configure-a-kubernetes-cluster-w.md
+++ b/docs/collections/Build your very own self-hosting platform with Raspberry Pi and Kubernetes/(38)-install-and-configure-a-kubernetes-cluster-w.md
@@ -293,10 +293,10 @@ version.BuildInfo{Version:"v3.0.2", GitCommit:"19e47ee3283ae98139d98460de796c1be
 <br />
 **3. Add the repository for official charts**
 
-Configure the repository `stable https://kubernetes-charts.storage.googleapis.com` to access the [official charts](https://github.com/helm/charts/tree/master/stable)
+Configure the repository `stable https://charts.helm.sh/stable` to access the [official charts](https://github.com/helm/charts/tree/master/stable)
 
 ```
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm repo add stable https://charts.helm.sh/stable
 "stable" has been added to your repositories
 
 $ helm repo update


### PR DESCRIPTION
## Purpose

This PR aims to correct an error happening when trying to add a helm charts 'deprecated' repository:

## Issue

When executing: `helm repo add stable https://kubernetes-charts.storage.googleapis.com`, this is the output

```bash
Error: repo "https://kubernetes-charts.storage.googleapis.com" is no longer available; try "https://charts.helm.sh/stable" instead
> helm repo add stable https://charts.helm.sh/stable
```

## Fix

```bash
helm repo add stable https://charts.helm.sh/stable
```

